### PR TITLE
Added forcing to installation and Tablescan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andi Bute <andi@projectricochet.com>
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \
     echo "deb http://repo.mongodb.org/apt/ubuntu "$(lsb_release -sc)"/mongodb-org/3.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list && \
     apt-get update && \
-    apt-get install -y mongodb-org-shell mongodb-org-tools && \
+    apt-get install -y --force-yes mongodb-org-shell mongodb-org-tools && \
     echo "mongodb-org-shell hold" | dpkg --set-selections && \
     echo "mongodb-org-tools hold" | dpkg --set-selections && \
     mkdir /backup

--- a/fetch_from_target.sh
+++ b/fetch_from_target.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BACKUP_CMD="mongodump --host $MONGODB_SRC_HOST --db $MONGODB_SRC_DB --out /backup/dump ";
+BACKUP_CMD="mongodump --forceTableScan --host $MONGODB_SRC_HOST --db $MONGODB_SRC_DB --out /backup/dump ";
 
 
 if [ ! -z "$MONGODB_SRC_PORT" ];


### PR DESCRIPTION
I have added the `--force-yes` to the apt-install of mongodb-tools aswell as the `--forceTableScan` to the mongodump.
This is a fix for the script not successfully running.